### PR TITLE
Add MariaDB docker-compose for testing

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -81,3 +81,15 @@ Welcome to **FREEDOM NOT FOUND - 404**, a terminal-based Java puzzle game that c
 ## Local Configuration
 
 Create a file named `src/main/resources/config.local.yml` to override the default settings in `config.yml`. This file is ignored by Git so your local database credentials remain private. A template named `config.local.example.yml` is provided as a starting point.
+
+## Docker Setup
+
+A `docker-compose.yml` is provided to spin up a MariaDB instance for testing.
+It exposes port `3306` and uses `root`/`root` as the default credentials.
+Run the following command to start the database:
+
+```bash
+docker compose up -d
+```
+
+The database will create a `freedom404` schema on startup and persist data in a local Docker volume named `db_data`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  mariadb:
+    image: mariadb:10.6
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: root
+      MYSQL_PASSWORD: root
+      MYSQL_DATABASE: freedom404
+    ports:
+      - "3306:3306"
+    volumes:
+      - db_data:/var/lib/mysql
+volumes:
+  db_data:


### PR DESCRIPTION
## Summary
- add a simple MariaDB container for local testing
- document how to use it in the README

## Testing
- `mvn -q test` *(fails: PluginResolutionException, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68451e34396c8331b7f674dbd6e72cfb